### PR TITLE
Add VS Code extension for on-enter translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,13 @@ UN    SensorB
 ```
 
 Each input line is translated independently and blank lines are inserted between statements. Comments starting with `//` are ignored.
+
+You can also translate a single line by passing it as an argument:
+
+```bash
+python transpile.py "Result = 1 + 2"
+```
+
+## VS Code
+
+An experimental extension lives under `vscode-extension`. Open this folder in VS Code and press `F5` to launch a development instance. Files with the `.pseudo` extension use the custom pseudocode language: when you press **Enter** at the end of a line, the line is replaced with its AWL translation by calling `transpile.py`.

--- a/transpile.py
+++ b/transpile.py
@@ -327,5 +327,8 @@ def transpile_line(line: str) -> str:
         return f"// unsupported: {lhs} = {rhs}"
 
 if __name__ == "__main__":
-    lines = [l for l in sys.stdin.read().splitlines() if l.strip()]
+    if len(sys.argv) > 1:
+        lines = [l for l in sys.argv[1:] if l.strip()]
+    else:
+        lines = [l for l in sys.stdin.read().splitlines() if l.strip()]
     print("\n\n".join(transpile_line(l) for l in lines))

--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -1,0 +1,42 @@
+const vscode = require('vscode');
+const cp = require('child_process');
+const path = require('path');
+
+function activate(context) {
+    const disposable = vscode.workspace.onDidChangeTextDocument(event => {
+        const editor = vscode.window.activeTextEditor;
+        if (!editor || event.document !== editor.document) {
+            return;
+        }
+        for (const change of event.contentChanges) {
+            if (change.text === '\n') {
+                const line = change.range.start.line;
+                const lineText = event.document.lineAt(line).text.trim();
+                if (!lineText) {
+                    continue;
+                }
+                const script = path.join(context.extensionPath, '..', 'transpile.py');
+                try {
+                    const res = cp.spawnSync('python3', [script, lineText], { encoding: 'utf8' });
+                    if (res.status === 0 && res.stdout) {
+                        editor.edit(edit => {
+                            const start = new vscode.Position(line, 0);
+                            const end = new vscode.Position(line, event.document.lineAt(line).text.length);
+                            edit.replace(new vscode.Range(start, end), res.stdout.trim());
+                        });
+                    }
+                } catch (err) {
+                    console.error(err);
+                }
+            }
+        }
+    });
+    context.subscriptions.push(disposable);
+}
+
+function deactivate() {}
+
+module.exports = {
+    activate,
+    deactivate
+};

--- a/vscode-extension/language-configuration.json
+++ b/vscode-extension/language-configuration.json
@@ -1,0 +1,5 @@
+{
+  "comments": {
+    "lineComment": "//"
+  }
+}

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "pseudocode-to-awl",
+  "displayName": "Pseudocode to AWL",
+  "description": "Translate pseudocode lines to AWL on Enter.",
+  "version": "0.0.1",
+  "publisher": "local",
+  "engines": {
+    "vscode": "^1.70.0"
+  },
+  "categories": ["Other"],
+  "activationEvents": [
+    "onLanguage:pseudocode"
+  ],
+  "main": "./extension.js",
+  "contributes": {
+    "languages": [
+      {
+        "id": "pseudocode",
+        "aliases": ["Pseudocode"],
+        "extensions": [".pseudo"],
+        "configuration": "./language-configuration.json"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- allow `transpile.py` to accept lines via CLI args
- add experimental VS Code extension translating pseudocode to AWL on Enter
- document single-line usage and VS Code setup

## Testing
- `python3 transpile.py "Result = 1 + 2"`


------
https://chatgpt.com/codex/tasks/task_e_68a46c08866883218a44e481861ae83a