### PR TITLE
feat: add web translator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/dist/main.js
+++ b/dist/main.js
@@ -1,0 +1,21 @@
+import { pseudocodeToAwl, awlToPseudocode } from './translator';
+const pseudo = document.getElementById('pseudocode');
+const awl = document.getElementById('awl');
+let lockLeft = false;
+let lockRight = false;
+pseudo.addEventListener('input', () => {
+    if (lockLeft)
+        return;
+    const res = pseudocodeToAwl(pseudo.value);
+    lockRight = true;
+    awl.value = res;
+    lockRight = false;
+});
+awl.addEventListener('input', () => {
+    if (lockRight)
+        return;
+    const res = awlToPseudocode(awl.value);
+    lockLeft = true;
+    pseudo.value = res;
+    lockLeft = false;
+});

--- a/dist/translator.js
+++ b/dist/translator.js
@@ -1,0 +1,186 @@
+function tokenizeBool(s) {
+    s = s.replace(/\(/g, ' ( ').replace(/\)/g, ' ) ');
+    const parts = [];
+    let buf = [];
+    let inq = false;
+    for (const ch of s) {
+        if (ch === '"' && !inq) {
+            inq = true;
+            buf.push(ch);
+            continue;
+        }
+        if (ch === '"' && inq) {
+            inq = false;
+            buf.push(ch);
+            continue;
+        }
+        if (inq) {
+            buf.push(ch);
+            continue;
+        }
+        buf.push(ch.match(/\s/) ? ' ' : ch);
+    }
+    return buf.join('').split(/\s+/).filter(Boolean);
+}
+function parseBool(tokens) {
+    let i = 0;
+    function peek() { return i < tokens.length ? tokens[i] : null; }
+    function eat(x) {
+        if (x === undefined)
+            return tokens[i++];
+        if (tokens[i] === x) {
+            i++;
+            return x;
+        }
+        throw new Error('expected ' + x);
+    }
+    function p_expr() {
+        let node = p_and();
+        while (true) {
+            const t = peek();
+            if (t && (t.toUpperCase() === 'OR' || t.toUpperCase() === 'ODER')) {
+                eat();
+                node = { kind: 'or', a: node, b: p_and() };
+            }
+            else
+                break;
+        }
+        return node;
+    }
+    function p_and() {
+        let node = p_not();
+        while (true) {
+            const t = peek();
+            if (t && (t.toUpperCase() === 'AND' || t.toUpperCase() === 'UND')) {
+                eat();
+                node = { kind: 'and', a: node, b: p_not() };
+            }
+            else
+                break;
+        }
+        return node;
+    }
+    function p_not() {
+        let neg = false;
+        while (true) {
+            const t = peek();
+            if (t && (t.toUpperCase() === 'NOT' || t.toUpperCase() === 'NICHT')) {
+                eat();
+                neg = !neg;
+            }
+            else
+                break;
+        }
+        const node = p_primary();
+        return neg ? { kind: 'not', a: node } : node;
+    }
+    function p_primary() {
+        const t = peek();
+        if (t === '(') {
+            eat('(');
+            const node = p_expr();
+            eat(')');
+            return node;
+        }
+        if (t) {
+            eat();
+            return { kind: 'id', a: t };
+        }
+        throw new Error('bad token');
+    }
+    const ast = p_expr();
+    if (i !== tokens.length)
+        throw new Error('trailing tokens');
+    return ast;
+}
+function op(role, neg) {
+    return { 'first': neg ? 'AN' : 'A', 'AND': neg ? 'UN' : 'U', 'OR': neg ? 'ON' : 'O' }[role];
+}
+function emitBool(node, role = 'first', neg = false, out = []) {
+    if (node.kind === 'id') {
+        out.push(`${op(role, neg).padEnd(5)} ${node.a}`);
+        return out;
+    }
+    if (node.kind === 'not') {
+        return emitBool(node.a, role, !neg, out);
+    }
+    if (node.kind === 'and') {
+        emitBool(node.a, role, neg, out);
+        emitBool(node.b, 'AND', false, out);
+        return out;
+    }
+    if (node.kind === 'or') {
+        if (role === 'first') {
+            emitBool(node.a, 'first', false, out);
+            emitBool(node.b, 'OR', neg, out);
+        }
+        else {
+            emitBool(node.a, role, neg, out);
+            emitBool(node.b, 'OR', neg, out);
+        }
+        return out;
+    }
+    return out;
+}
+export function pseudocodeToAwl(input) {
+    const lines = input.split(/\r?\n/);
+    const result = [];
+    for (const raw of lines) {
+        let line = raw.replace(/\/\/.*$/, '').trim();
+        if (!line)
+            continue;
+        if (!line.includes('=')) {
+            result.push(`// unsupported: ${line}`);
+            continue;
+        }
+        const [lhs, rhs] = line.split('=').map(s => s.trim());
+        try {
+            const tokens = tokenizeBool(rhs);
+            const ast = parseBool(tokens);
+            const awl = [];
+            emitBool(ast, 'first', false, awl);
+            awl.push(`=     ${lhs}`);
+            result.push(awl.join('\n'));
+        }
+        catch (_a) {
+            result.push(`// unsupported: ${line}`);
+        }
+    }
+    return result.join('\n');
+}
+export function awlToPseudocode(input) {
+    const lines = input.split(/\r?\n/);
+    const result = [];
+    let block = [];
+    for (const raw of lines) {
+        const line = raw.trim();
+        if (!line)
+            continue;
+        block.push(line);
+        if (line.startsWith('=')) {
+            const lhs = line.slice(1).trim();
+            let expr = '';
+            for (let i = 0; i < block.length - 1; i++) {
+                const parts = block[i].trim().split(/\s+/);
+                if (parts.length < 2)
+                    continue;
+                const [opCode, ...rest] = parts;
+                const id = rest.join(' ');
+                const neg = opCode.endsWith('N');
+                const term = (neg ? 'NOT ' : '') + id;
+                if (opCode.startsWith('A') && expr === '') {
+                    expr = term;
+                }
+                else if (opCode.startsWith('U') || (opCode.startsWith('A') && expr !== '')) {
+                    expr += ` AND ${term}`;
+                }
+                else if (opCode.startsWith('O')) {
+                    expr += ` OR ${term}`;
+                }
+            }
+            result.push(`${lhs} = ${expr}`);
+            block = [];
+        }
+    }
+    return result.join('\n');
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Pseudocode ⇄ AWL Translator</title>
+  <style>
+    body { margin: 0; font-family: Arial, sans-serif; background: #f5f5f5; color: #333; }
+    .container { display: flex; height: 100vh; }
+    textarea { flex: 1; padding: 1rem; border: none; resize: none; font-family: monospace; font-size: 1rem; }
+    textarea:focus { outline: none; }
+    .left { border-right: 1px solid #ddd; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <textarea id="pseudocode" class="left" placeholder="Pseudocode"></textarea>
+    <textarea id="awl" placeholder="AWL"></textarea>
+  </div>
+  <script type="module" src="./dist/main.js"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "pseudocode_to_awl",
+  "version": "1.0.0",
+  "description": "This repository contains a small Python script that converts simple pseudo code / structured text to **AWL** instructions (the Siemens S7 PLC assembly language).",
+  "main": "index.js",
+  "scripts": {
+    "build": "tsc"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module"
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,23 @@
+import { pseudocodeToAwl, awlToPseudocode } from './translator';
+
+const pseudo = document.getElementById('pseudocode') as HTMLTextAreaElement;
+const awl = document.getElementById('awl') as HTMLTextAreaElement;
+
+let lockLeft = false;
+let lockRight = false;
+
+pseudo.addEventListener('input', () => {
+  if (lockLeft) return;
+  const res = pseudocodeToAwl(pseudo.value);
+  lockRight = true;
+  awl.value = res;
+  lockRight = false;
+});
+
+awl.addEventListener('input', () => {
+  if (lockRight) return;
+  const res = awlToPseudocode(awl.value);
+  lockLeft = true;
+  pseudo.value = res;
+  lockLeft = false;
+});

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -1,0 +1,150 @@
+export type BNode = { kind: 'id' | 'not' | 'and' | 'or', a?: BNode | string, b?: BNode };
+
+function tokenizeBool(s: string): string[] {
+  s = s.replace(/\(/g, ' ( ').replace(/\)/g, ' ) ');
+  const parts: string[] = [];
+  let buf: string[] = [];
+  let inq = false;
+  for (const ch of s) {
+    if (ch === '"' && !inq) { inq = true; buf.push(ch); continue; }
+    if (ch === '"' && inq) { inq = false; buf.push(ch); continue; }
+    if (inq) { buf.push(ch); continue; }
+    buf.push(ch.match(/\s/) ? ' ' : ch);
+  }
+  return buf.join('').split(/\s+/).filter(Boolean);
+}
+
+function parseBool(tokens: string[]): BNode {
+  let i = 0;
+  function peek(): string | null { return i < tokens.length ? tokens[i] : null; }
+  function eat(x?: string): string {
+    if (x === undefined) return tokens[i++];
+    if (tokens[i] === x) { i++; return x; }
+    throw new Error('expected ' + x);
+  }
+  function p_expr(): BNode {
+    let node = p_and();
+    while (true) {
+      const t = peek();
+      if (t && (t.toUpperCase() === 'OR' || t.toUpperCase() === 'ODER')) {
+        eat(); node = { kind: 'or', a: node, b: p_and() };
+      } else break;
+    }
+    return node;
+  }
+  function p_and(): BNode {
+    let node = p_not();
+    while (true) {
+      const t = peek();
+      if (t && (t.toUpperCase() === 'AND' || t.toUpperCase() === 'UND')) {
+        eat(); node = { kind: 'and', a: node, b: p_not() };
+      } else break;
+    }
+    return node;
+  }
+  function p_not(): BNode {
+    let neg = false;
+    while (true) {
+      const t = peek();
+      if (t && (t.toUpperCase() === 'NOT' || t.toUpperCase() === 'NICHT')) {
+        eat(); neg = !neg;
+      } else break;
+    }
+    const node = p_primary();
+    return neg ? { kind: 'not', a: node } : node;
+  }
+  function p_primary(): BNode {
+    const t = peek();
+    if (t === '(') { eat('('); const node = p_expr(); eat(')'); return node; }
+    if (t) { eat(); return { kind: 'id', a: t }; }
+    throw new Error('bad token');
+  }
+  const ast = p_expr();
+  if (i !== tokens.length) throw new Error('trailing tokens');
+  return ast;
+}
+
+function op(role: 'first' | 'AND' | 'OR', neg: boolean): string {
+  return { 'first': neg ? 'AN' : 'A', 'AND': neg ? 'UN' : 'U', 'OR': neg ? 'ON' : 'O' }[role];
+}
+
+function emitBool(node: BNode, role: 'first' | 'AND' | 'OR' = 'first', neg = false, out: string[] = []): string[] {
+  if (node.kind === 'id') {
+    out.push(`${op(role, neg).padEnd(5)} ${node.a}`);
+    return out;
+  }
+  if (node.kind === 'not') {
+    return emitBool(node.a as BNode, role, !neg, out);
+  }
+  if (node.kind === 'and') {
+    emitBool(node.a as BNode, role, neg, out);
+    emitBool(node.b as BNode, 'AND', false, out);
+    return out;
+  }
+  if (node.kind === 'or') {
+    if (role === 'first') {
+      emitBool(node.a as BNode, 'first', false, out);
+      emitBool(node.b as BNode, 'OR', neg, out);
+    } else {
+      emitBool(node.a as BNode, role, neg, out);
+      emitBool(node.b as BNode, 'OR', neg, out);
+    }
+    return out;
+  }
+  return out;
+}
+
+export function pseudocodeToAwl(input: string): string {
+  const lines = input.split(/\r?\n/);
+  const result: string[] = [];
+  for (const raw of lines) {
+    let line = raw.replace(/\/\/.*$/, '').trim();
+    if (!line) continue;
+    if (!line.includes('=')) { result.push(`// unsupported: ${line}`); continue; }
+    const [lhs, rhs] = line.split('=').map(s => s.trim());
+    try {
+      const tokens = tokenizeBool(rhs);
+      const ast = parseBool(tokens);
+      const awl: string[] = [];
+      emitBool(ast, 'first', false, awl);
+      awl.push(`=     ${lhs}`);
+      result.push(awl.join('\n'));
+    } catch {
+      result.push(`// unsupported: ${line}`);
+    }
+  }
+  return result.join('\n');
+}
+
+export function awlToPseudocode(input: string): string {
+  const lines = input.split(/\r?\n/);
+  const result: string[] = [];
+  let block: string[] = [];
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!line) continue;
+    block.push(line);
+    if (line.startsWith('=')) {
+      const lhs = line.slice(1).trim();
+      let expr = '';
+      for (let i = 0; i < block.length - 1; i++) {
+        const parts = block[i].trim().split(/\s+/);
+        if (parts.length < 2) continue;
+        const [opCode, ...rest] = parts;
+        const id = rest.join(' ');
+        const neg = opCode.endsWith('N');
+        const term = (neg ? 'NOT ' : '') + id;
+        if (opCode.startsWith('A') && expr === '') {
+          expr = term;
+        } else if (opCode.startsWith('U') || (opCode.startsWith('A') && expr !== '')) {
+          expr += ` AND ${term}`;
+        } else if (opCode.startsWith('O')) {
+          expr += ` OR ${term}`;
+        }
+      }
+      result.push(`${lhs} = ${expr}`);
+      block = [];
+    }
+  }
+  return result.join('\n');
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "module": "es6",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- add a simple two-pane web UI for converting pseudocode to AWL and back
- implement TypeScript translator for boolean expressions
- add build config for TypeScript

## Testing
- `npm run build`
- `node -e "import('./dist/translator.js').then(m=>console.log(m.pseudocodeToAwl('X = A AND B')));"`
- `node -e "import('./dist/translator.js').then(m=>console.log(m.awlToPseudocode('A     A\nU     B\n=     X')));"`


------
https://chatgpt.com/codex/tasks/task_e_68a471f76dc08321b97b1caba279677c